### PR TITLE
Fix Claude CLI not found when launched from macOS Finder

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -36,7 +36,7 @@ fn ensure_full_path() -> String {
     let nvm_dir = format!("{}/.nvm/versions/node", home);
     if let Ok(entries) = std::fs::read_dir(&nvm_dir) {
         let mut versions: Vec<_> = entries.filter_map(|e| e.ok()).collect();
-        versions.sort_by(|a, b| b.file_name().cmp(&a.file_name()));
+        versions.sort_by_key(|e| std::cmp::Reverse(e.file_name()));
         if let Some(latest) = versions.first() {
             let bin = latest.path().join("bin");
             let bin_str = bin.to_string_lossy().to_string();


### PR DESCRIPTION
## Summary

Fixes "Claude CLI not found" when Forge is launched from Finder/Dock/Spotlight instead of a terminal.

## Problem

macOS apps launched from Finder get a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that doesn't include directories where `claude` is typically installed:
- `~/.local/bin` (npm global with `--prefix`)
- `~/.nvm/versions/node/*/bin` (nvm)
- `~/.fnm/aliases/default/bin` (fnm)
- `/usr/local/bin`, `/opt/homebrew/bin` (Homebrew)
- `~/.cargo/bin` (cargo)

## Fix

Added `ensure_full_path()` that augments the PATH with common CLI tool install locations. It's used by both `check_claude_cli` (so the status check works) and `spawn_terminal` (so PTY sessions can find `claude` and other tools).

## Test plan

- [x] All 48 Rust tests pass
- [ ] Manual: launch Forge from Finder, verify Claude CLI is detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)