### PR TITLE
Improve skills: full install, quick actions, live marketplace

### DIFF
--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[derive(Debug, Serialize)]
@@ -140,6 +140,93 @@ pub fn get_skills(project_path: Option<String>) -> Result<Vec<Skill>, String> {
     Ok(skills)
 }
 
+/// Entry from the GitHub Contents API response
+#[derive(Debug, Deserialize)]
+struct GitHubContentEntry {
+    name: String,
+    #[serde(rename = "type")]
+    entry_type: String, // "file" or "dir"
+    download_url: Option<String>,
+    path: String,
+}
+
+/// Download a single file from a URL to a local path
+fn download_file(url: &str, dest: &Path) -> Result<(), String> {
+    let output = Command::new("curl")
+        .args(["-s", "--fail", "--max-redirs", "0", "-L", url])
+        .output()
+        .map_err(|e| format!("Failed to run curl: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!("Download failed for {}", url));
+    }
+
+    fs::write(dest, &output.stdout)
+        .map_err(|e| format!("Failed to write {}: {}", dest.display(), e))
+}
+
+/// Recursively download a GitHub directory using the Contents API
+fn download_github_directory(api_url: &str, target_dir: &Path) -> Result<(), String> {
+    fs::create_dir_all(target_dir)
+        .map_err(|e| format!("Failed to create directory: {}", e))?;
+
+    // Fetch directory listing from GitHub Contents API
+    let output = Command::new("curl")
+        .args([
+            "-s", "--fail",
+            "-H", "Accept: application/vnd.github.v3+json",
+            "-H", "User-Agent: Canopy",
+            api_url,
+        ])
+        .output()
+        .map_err(|e| format!("Failed to fetch directory listing: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!("GitHub API request failed for {}", api_url));
+    }
+
+    let entries: Vec<GitHubContentEntry> = serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("Failed to parse GitHub API response: {}", e))?;
+
+    for entry in entries {
+        match entry.entry_type.as_str() {
+            "file" => {
+                if let Some(ref dl_url) = entry.download_url {
+                    let dest = target_dir.join(&entry.name);
+                    download_file(dl_url, &dest)?;
+                }
+            }
+            "dir" => {
+                let sub_api = format!(
+                    "https://api.github.com/repos/{}/contents/{}",
+                    // Extract owner/repo from the API URL
+                    extract_repo_from_api_url(api_url).unwrap_or_default(),
+                    entry.path,
+                );
+                let sub_dir = target_dir.join(&entry.name);
+                download_github_directory(&sub_api, &sub_dir)?;
+            }
+            _ => {} // skip symlinks etc.
+        }
+    }
+
+    Ok(())
+}
+
+/// Extract "owner/repo" from a GitHub API URL like
+/// "https://api.github.com/repos/anthropics/skills/contents/skills/pdf"
+fn extract_repo_from_api_url(url: &str) -> Option<String> {
+    let prefix = "https://api.github.com/repos/";
+    let rest = url.strip_prefix(prefix)?;
+    // rest = "anthropics/skills/contents/skills/pdf"
+    let parts: Vec<&str> = rest.splitn(3, '/').collect();
+    if parts.len() >= 2 {
+        Some(format!("{}/{}", parts[0], parts[1]))
+    } else {
+        None
+    }
+}
+
 #[tauri::command]
 pub fn install_skill(id: String, source_url: String, format: String) -> InstallResult {
     // Validate skill id — prevent path traversal
@@ -177,64 +264,80 @@ pub fn install_skill(id: String, source_url: String, format: String) -> InstallR
         }
     };
 
-    let (target_dir, target_file) = if format == "command" {
-        let dir = home.join(".claude").join("commands");
-        let file = dir.join(format!("{}.md", id));
-        (dir, file)
-    } else {
-        let dir = home.join(".claude").join("skills").join(&id);
-        let file = dir.join("SKILL.md");
-        (dir, file)
-    };
+    if format == "command" {
+        // Single file download for commands
+        let target_dir = home.join(".claude").join("commands");
+        let target_file = target_dir.join(format!("{}.md", id));
 
-    // Create directory if needed
-    if let Err(e) = fs::create_dir_all(&target_dir) {
-        return InstallResult {
-            success: false,
-            id,
-            installed_path: None,
-            error: Some(format!("Failed to create directory: {}", e)),
-        };
-    }
-
-    // Download via curl (no redirects — raw.githubusercontent.com serves directly)
-    let output = Command::new("curl")
-        .args(["-s", "--fail", "--max-redirs", "0", &source_url])
-        .output();
-
-    match output {
-        Ok(result) => {
-            if !result.status.success() {
-                let stderr = String::from_utf8_lossy(&result.stderr);
-                return InstallResult {
-                    success: false,
-                    id,
-                    installed_path: None,
-                    error: Some(format!("Download failed: {}", stderr)),
-                };
-            }
-
-            match fs::write(&target_file, &result.stdout) {
-                Ok(_) => InstallResult {
-                    success: true,
-                    id,
-                    installed_path: Some(target_file.to_string_lossy().to_string()),
-                    error: None,
-                },
-                Err(e) => InstallResult {
-                    success: false,
-                    id,
-                    installed_path: None,
-                    error: Some(format!("Failed to write file: {}", e)),
-                },
-            }
+        if let Err(e) = fs::create_dir_all(&target_dir) {
+            return InstallResult {
+                success: false,
+                id,
+                installed_path: None,
+                error: Some(format!("Failed to create directory: {}", e)),
+            };
         }
-        Err(e) => InstallResult {
-            success: false,
-            id,
-            installed_path: None,
-            error: Some(format!("Failed to run curl: {}", e)),
-        },
+
+        match download_file(&source_url, &target_file) {
+            Ok(_) => InstallResult {
+                success: true,
+                id,
+                installed_path: Some(target_file.to_string_lossy().to_string()),
+                error: None,
+            },
+            Err(e) => InstallResult {
+                success: false,
+                id,
+                installed_path: None,
+                error: Some(e),
+            },
+        }
+    } else {
+        // Full directory download for skills
+        // Derive GitHub API URL from the raw.githubusercontent.com source URL
+        // source_url: https://raw.githubusercontent.com/anthropics/skills/main/skills/pdf/SKILL.md
+        // api_url:    https://api.github.com/repos/anthropics/skills/contents/skills/pdf
+        let api_url = source_url
+            .replace("https://raw.githubusercontent.com/", "https://api.github.com/repos/")
+            .replace("/main/", "/contents/")
+            .replace("/master/", "/contents/")
+            .trim_end_matches("/SKILL.md")
+            .to_string();
+
+        let target_dir = home.join(".claude").join("skills").join(&id);
+
+        // Remove existing skill directory if present (clean reinstall)
+        if target_dir.exists() {
+            let _ = fs::remove_dir_all(&target_dir);
+        }
+
+        match download_github_directory(&api_url, &target_dir) {
+            Ok(_) => {
+                // Verify SKILL.md was downloaded
+                let skill_file = target_dir.join("SKILL.md");
+                if skill_file.exists() {
+                    InstallResult {
+                        success: true,
+                        id,
+                        installed_path: Some(target_dir.to_string_lossy().to_string()),
+                        error: None,
+                    }
+                } else {
+                    InstallResult {
+                        success: false,
+                        id,
+                        installed_path: None,
+                        error: Some("SKILL.md not found in downloaded directory".to_string()),
+                    }
+                }
+            }
+            Err(e) => InstallResult {
+                success: false,
+                id,
+                installed_path: None,
+                error: Some(e),
+            },
+        }
     }
 }
 
@@ -319,6 +422,109 @@ pub fn check_skills_installed(skill_ids: Vec<(String, String)>) -> Vec<Installed
             }
         })
         .collect()
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarketplaceSkill {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub source_url: String,
+    pub repo_url: String,
+}
+
+/// Fetch available skills from a GitHub repository's skills/ directory.
+/// Uses the GitHub Contents API to list skill directories and reads SKILL.md metadata.
+#[tauri::command]
+pub fn fetch_marketplace_skills(repo: Option<String>) -> Result<Vec<MarketplaceSkill>, String> {
+    let repo = repo.unwrap_or_else(|| "anthropics/skills".to_string());
+
+    // Validate repo format (owner/repo)
+    if !repo.contains('/') || repo.matches('/').count() != 1 {
+        return Err("Invalid repo format. Expected 'owner/repo'.".to_string());
+    }
+
+    let api_url = format!(
+        "https://api.github.com/repos/{}/contents/skills",
+        repo
+    );
+
+    let output = Command::new("curl")
+        .args([
+            "-s", "--fail",
+            "-H", "Accept: application/vnd.github.v3+json",
+            "-H", "User-Agent: Canopy",
+            &api_url,
+        ])
+        .output()
+        .map_err(|e| format!("Failed to fetch marketplace: {}", e))?;
+
+    if !output.status.success() {
+        return Err("Failed to fetch skills directory from GitHub".to_string());
+    }
+
+    let entries: Vec<GitHubContentEntry> = serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("Failed to parse GitHub response: {}", e))?;
+
+    let mut skills: Vec<MarketplaceSkill> = Vec::new();
+
+    for entry in entries {
+        if entry.entry_type != "dir" {
+            continue;
+        }
+
+        let skill_id = entry.name.clone();
+
+        // Fetch SKILL.md to get metadata
+        let skill_url = format!(
+            "https://raw.githubusercontent.com/{}/main/skills/{}/SKILL.md",
+            repo, skill_id
+        );
+
+        let md_output = Command::new("curl")
+            .args(["-s", "--fail", &skill_url])
+            .output();
+
+        let (name, description) = match md_output {
+            Ok(ref result) if result.status.success() => {
+                let content = String::from_utf8_lossy(&result.stdout);
+                let content = skip_yaml_frontmatter(&content);
+                let mut lines = content.lines();
+                let title = lines
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .trim_start_matches('#')
+                    .trim()
+                    .to_string();
+                lines.next(); // skip blank line
+                let desc = lines.next().unwrap_or("").trim().to_string();
+                (
+                    if title.is_empty() { skill_id.clone() } else { title },
+                    desc,
+                )
+            }
+            _ => (skill_id.clone(), String::new()),
+        };
+
+        skills.push(MarketplaceSkill {
+            id: skill_id.clone(),
+            name,
+            description,
+            source_url: format!(
+                "https://raw.githubusercontent.com/{}/main/skills/{}/SKILL.md",
+                repo, skill_id
+            ),
+            repo_url: format!(
+                "https://github.com/{}/tree/main/skills/{}",
+                repo, skill_id
+            ),
+        });
+    }
+
+    skills.sort_by(|a, b| a.id.to_lowercase().cmp(&b.id.to_lowercase()));
+    Ok(skills)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -153,7 +153,7 @@ struct GitHubContentEntry {
 /// Download a single file from a URL to a local path
 fn download_file(url: &str, dest: &Path) -> Result<(), String> {
     let output = Command::new("curl")
-        .args(["-s", "--fail", "--max-redirs", "0", "-L", url])
+        .args(["-s", "--fail", "--connect-timeout", "10", "--max-time", "30", url])
         .output()
         .map_err(|e| format!("Failed to run curl: {}", e))?;
 
@@ -165,8 +165,18 @@ fn download_file(url: &str, dest: &Path) -> Result<(), String> {
         .map_err(|e| format!("Failed to write {}: {}", dest.display(), e))
 }
 
-/// Recursively download a GitHub directory using the Contents API
+/// Recursively download a GitHub directory using the Contents API.
+/// `depth` limits recursion to prevent stack overflow from malicious repos.
+const MAX_DOWNLOAD_DEPTH: u32 = 5;
+
 fn download_github_directory(api_url: &str, target_dir: &Path) -> Result<(), String> {
+    download_github_directory_inner(api_url, target_dir, 0)
+}
+
+fn download_github_directory_inner(api_url: &str, target_dir: &Path, depth: u32) -> Result<(), String> {
+    if depth > MAX_DOWNLOAD_DEPTH {
+        return Err("Directory nesting too deep (max 5 levels)".to_string());
+    }
     fs::create_dir_all(target_dir)
         .map_err(|e| format!("Failed to create directory: {}", e))?;
 
@@ -174,6 +184,8 @@ fn download_github_directory(api_url: &str, target_dir: &Path) -> Result<(), Str
     let output = Command::new("curl")
         .args([
             "-s", "--fail",
+            "--connect-timeout", "10",
+            "--max-time", "30",
             "-H", "Accept: application/vnd.github.v3+json",
             "-H", "User-Agent: Canopy",
             api_url,
@@ -200,11 +212,12 @@ fn download_github_directory(api_url: &str, target_dir: &Path) -> Result<(), Str
                 let sub_api = format!(
                     "https://api.github.com/repos/{}/contents/{}",
                     // Extract owner/repo from the API URL
-                    extract_repo_from_api_url(api_url).unwrap_or_default(),
+                    extract_repo_from_api_url(api_url)
+                        .ok_or_else(|| "Failed to parse repo from API URL".to_string())?,
                     entry.path,
                 );
                 let sub_dir = target_dir.join(&entry.name);
-                download_github_directory(&sub_api, &sub_dir)?;
+                download_github_directory_inner(&sub_api, &sub_dir, depth + 1)?;
             }
             _ => {} // skip symlinks etc.
         }
@@ -294,21 +307,43 @@ pub fn install_skill(id: String, source_url: String, format: String) -> InstallR
         }
     } else {
         // Full directory download for skills
-        // Derive GitHub API URL from the raw.githubusercontent.com source URL
+        // Parse the raw.githubusercontent.com URL structurally:
         // source_url: https://raw.githubusercontent.com/anthropics/skills/main/skills/pdf/SKILL.md
-        // api_url:    https://api.github.com/repos/anthropics/skills/contents/skills/pdf
-        let api_url = source_url
-            .replace("https://raw.githubusercontent.com/", "https://api.github.com/repos/")
-            .replace("/main/", "/contents/")
-            .replace("/master/", "/contents/")
-            .trim_end_matches("/SKILL.md")
-            .to_string();
+        // → owner=anthropics, repo=skills, branch=main, path=skills/pdf/SKILL.md
+        // → api_url: https://api.github.com/repos/anthropics/skills/contents/skills/pdf
+        let api_url = match source_url.strip_prefix("https://raw.githubusercontent.com/") {
+            Some(rest) => {
+                let parts: Vec<&str> = rest.splitn(4, '/').collect();
+                if parts.len() < 4 {
+                    return InstallResult {
+                        success: false,
+                        id,
+                        installed_path: None,
+                        error: Some("Invalid source URL format".to_string()),
+                    };
+                }
+                let (owner, repo, _branch, file_path) = (parts[0], parts[1], parts[2], parts[3]);
+                let dir_path = file_path.trim_end_matches("/SKILL.md").trim_end_matches("SKILL.md");
+                let dir_path = dir_path.trim_end_matches('/');
+                format!("https://api.github.com/repos/{}/{}/contents/{}", owner, repo, dir_path)
+            }
+            None => {
+                return InstallResult {
+                    success: false,
+                    id,
+                    installed_path: None,
+                    error: Some("Source URL must be from raw.githubusercontent.com".to_string()),
+                };
+            }
+        };
 
         let target_dir = home.join(".claude").join("skills").join(&id);
 
         // Remove existing skill directory if present (clean reinstall)
         if target_dir.exists() {
-            let _ = fs::remove_dir_all(&target_dir);
+            fs::remove_dir_all(&target_dir)
+                .map_err(|e| format!("Failed to clean existing skill directory: {}", e))
+                .unwrap_or_else(|e| eprintln!("{}", e));
         }
 
         match download_github_directory(&api_url, &target_dir) {
@@ -441,8 +476,13 @@ pub fn fetch_marketplace_skills(repo: Option<String>) -> Result<Vec<MarketplaceS
     let repo = repo.unwrap_or_else(|| "anthropics/skills".to_string());
 
     // Validate repo format (owner/repo)
-    if !repo.contains('/') || repo.matches('/').count() != 1 {
-        return Err("Invalid repo format. Expected 'owner/repo'.".to_string());
+    let repo_parts: Vec<&str> = repo.splitn(2, '/').collect();
+    if repo_parts.len() != 2
+        || repo_parts[0].is_empty()
+        || repo_parts[1].is_empty()
+        || !repo_parts.iter().all(|p| p.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == '.'))
+    {
+        return Err("Invalid repo format. Expected 'owner/repo' with alphanumeric characters, hyphens, underscores, or periods.".to_string());
     }
 
     let api_url = format!(
@@ -453,6 +493,8 @@ pub fn fetch_marketplace_skills(repo: Option<String>) -> Result<Vec<MarketplaceS
     let output = Command::new("curl")
         .args([
             "-s", "--fail",
+            "--connect-timeout", "10",
+            "--max-time", "30",
             "-H", "Accept: application/vnd.github.v3+json",
             "-H", "User-Agent: Canopy",
             &api_url,

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -201,9 +201,27 @@ fn download_github_directory_inner(api_url: &str, target_dir: &Path, depth: u32)
         .map_err(|e| format!("Failed to parse GitHub API response: {}", e))?;
 
     for entry in entries {
+        // Validate entry name — prevent path traversal from malicious API responses
+        if entry.name.is_empty()
+            || entry.name.contains('/')
+            || entry.name.contains('\\')
+            || entry.name.contains("..")
+        {
+            continue;
+        }
+
+        // Validate entry path — prevent URL injection in recursive calls
+        if entry.path.contains("..") || entry.path.contains('?') || entry.path.contains('#') {
+            continue;
+        }
+
         match entry.entry_type.as_str() {
             "file" => {
                 if let Some(ref dl_url) = entry.download_url {
+                    // Validate download URL against allowlist — prevent SSRF
+                    if !dl_url.starts_with("https://raw.githubusercontent.com/") {
+                        continue;
+                    }
                     let dest = target_dir.join(&entry.name);
                     download_file(dl_url, &dest)?;
                 }
@@ -211,7 +229,6 @@ fn download_github_directory_inner(api_url: &str, target_dir: &Path, depth: u32)
             "dir" => {
                 let sub_api = format!(
                     "https://api.github.com/repos/{}/contents/{}",
-                    // Extract owner/repo from the API URL
                     extract_repo_from_api_url(api_url)
                         .ok_or_else(|| "Failed to parse repo from API URL".to_string())?,
                     entry.path,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,6 +31,7 @@ pub fn run() {
             commands::skills::install_skill,
             commands::skills::uninstall_skill,
             commands::skills::check_skills_installed,
+            commands::skills::fetch_marketplace_skills,
             commands::github::get_github_items,
             commands::settings::save_keyring_secret,
             commands::settings::get_keyring_secret,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -448,6 +448,7 @@ function App() {
             onToggleSplit={toggleSplit}
             onNewTerminal={handleNewTerminal}
             onNewClaudeSession={handleNewClaude}
+            onNewClaudeWithPrompt={handleSendTaskToClaude}
             onReorderTabs={reorderTabs}
             hasDeadTabs={tabs.some((t) => t.dead)}
             onCloseAllDead={closeAllDeadTabs}

--- a/src/__tests__/tauri-contract.test.ts
+++ b/src/__tests__/tauri-contract.test.ts
@@ -48,6 +48,7 @@ const RUST_COMMANDS: Record<string, string[]> = {
   install_skill: ["id", "sourceUrl", "format"],
   uninstall_skill: ["id", "format"],
   check_skills_installed: ["skillIds"],
+  fetch_marketplace_skills: ["repo"],
 
   // settings.rs
   save_keyring_secret: ["key", "value"],

--- a/src/components/ActivityBar/SkillsPanel.tsx
+++ b/src/components/ActivityBar/SkillsPanel.tsx
@@ -26,7 +26,8 @@ export function SkillsPanel({ projectPath, onRunSkill, startOnBrowse, onBrowseMo
   const [browseFilter, setBrowseFilter] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<string>("All");
 
-  const { catalog, statuses, installing, install, uninstall } = useSkillStore();
+  const { catalog, statuses, installing, install, uninstall, fetchMarketplace, marketplaceLoading, marketplaceError } = useSkillStore();
+  const [repoInput, setRepoInput] = useState("");
 
   // Sync with external browse mode signal
   useEffect(() => {
@@ -163,10 +164,35 @@ export function SkillsPanel({ projectPath, onRunSkill, startOnBrowse, onBrowseMo
             <span className="skills-browse-count">{installedCount} installed</span>
           </div>
 
+          <div className="skills-repo-search">
+            <input
+              className="skills-search"
+              type="text"
+              placeholder="GitHub repo (e.g. owner/skills-repo)"
+              value={repoInput}
+              onChange={(e) => setRepoInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && repoInput.trim()) {
+                  fetchMarketplace(repoInput.trim());
+                }
+              }}
+            />
+            <button
+              className="skills-fetch-btn"
+              onClick={() => fetchMarketplace(repoInput.trim() || undefined)}
+              disabled={marketplaceLoading}
+            >
+              {marketplaceLoading ? "..." : repoInput.trim() ? "Search" : "Refresh"}
+            </button>
+          </div>
+          {marketplaceError && (
+            <div className="skills-error">{marketplaceError}</div>
+          )}
+
           <input
             className="skills-search"
             type="text"
-            placeholder="Search skills..."
+            placeholder="Filter skills..."
             value={browseFilter}
             onChange={(e) => setBrowseFilter(e.target.value)}
           />

--- a/src/components/Terminal/TerminalTabBar.tsx
+++ b/src/components/Terminal/TerminalTabBar.tsx
@@ -1,7 +1,16 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import type { TerminalTab as TerminalTabType } from "../../types/terminal";
 import { TerminalTab } from "./TerminalTab";
 import { HOME_TAB_ID } from "../../hooks/useTerminal";
+
+const QUICK_ACTIONS = [
+  { label: "Review PR", prompt: "Review the current branch's changes against main. Focus on bugs, edge cases, and code quality. Provide structured findings.", icon: ">" },
+  { label: "Fix Tests", prompt: "Find and fix any failing tests. Run the test suite first, then diagnose and fix each failure.", icon: ">" },
+  { label: "Commit", prompt: "/commit", icon: "/" },
+  { label: "Plan Feature", prompt: "/plan", icon: "/" },
+  { label: "Audit Code", prompt: "Perform a code review of recent changes. Check for bugs, security issues, and improvements.", icon: ">" },
+  { label: "Simplify", prompt: "/simplify", icon: "/" },
+];
 
 interface TerminalTabBarProps {
   tabs: TerminalTabType[];
@@ -12,6 +21,7 @@ interface TerminalTabBarProps {
   onToggleSplit: () => void;
   onNewTerminal: () => void;
   onNewClaudeSession: () => void;
+  onNewClaudeWithPrompt?: (prompt: string) => void;
   onReorderTabs?: (fromId: string, toId: string) => void;
   hasDeadTabs?: boolean;
   onCloseAllDead?: () => void;
@@ -26,11 +36,26 @@ export function TerminalTabBar({
   onToggleSplit,
   onNewTerminal,
   onNewClaudeSession,
+  onNewClaudeWithPrompt,
   onReorderTabs,
   hasDeadTabs,
   onCloseAllDead,
 }: TerminalTabBarProps) {
   const terminalCount = tabs.filter((t) => !t.isProjectOverview).length;
+  const [showActions, setShowActions] = useState(false);
+  const actionsRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    if (!showActions) return;
+    const handleClick = (e: MouseEvent) => {
+      if (actionsRef.current && !actionsRef.current.contains(e.target as Node)) {
+        setShowActions(false);
+      }
+    };
+    window.addEventListener("mousedown", handleClick);
+    return () => window.removeEventListener("mousedown", handleClick);
+  }, [showActions]);
 
   // Pointer-based tab reorder (avoids conflict with Tauri's native drag-drop)
   const [draggingTabId, setDraggingTabId] = useState<string | null>(null);
@@ -120,9 +145,37 @@ export function TerminalTabBar({
             Clear dead
           </button>
         )}
-        <button className="new-tab-btn" onClick={onNewClaudeSession} title="New Claude Session">
-          + Claude
-        </button>
+        <div className="new-tab-group" ref={actionsRef}>
+          <button className="new-tab-btn" onClick={onNewClaudeSession} title="New Claude Session">
+            + Claude
+          </button>
+          {onNewClaudeWithPrompt && (
+            <button
+              className="new-tab-btn dropdown-toggle"
+              onClick={() => setShowActions(!showActions)}
+              title="Quick actions"
+            >
+              {"\u25BE"}
+            </button>
+          )}
+          {showActions && onNewClaudeWithPrompt && (
+            <div className="quick-actions-dropdown">
+              {QUICK_ACTIONS.map((action) => (
+                <button
+                  key={action.label}
+                  className="quick-action-item"
+                  onClick={() => {
+                    onNewClaudeWithPrompt(action.prompt);
+                    setShowActions(false);
+                  }}
+                >
+                  <span className="quick-action-icon">{action.icon}</span>
+                  <span>{action.label}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
         <button className="new-tab-btn shell" onClick={onNewTerminal} title="New Terminal">
           + Shell
         </button>

--- a/src/hooks/useSkillStore.ts
+++ b/src/hooks/useSkillStore.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { SKILL_CATALOG } from "../data/skill-catalog";
 import type { CatalogSkill, InstalledSkillStatus, InstallResult } from "../types/skill-catalog";
@@ -19,12 +19,15 @@ export function useSkillStore() {
   const [marketplaceError, setMarketplaceError] = useState<string | null>(null);
 
   // Merged catalog: hardcoded + any live marketplace entries not already in hardcoded
-  const mergedCatalog = [...SKILL_CATALOG];
-  for (const ms of marketplaceSkills) {
-    if (!mergedCatalog.some((s) => s.id === ms.id)) {
-      mergedCatalog.push(ms);
+  const mergedCatalog = useMemo(() => {
+    const merged = [...SKILL_CATALOG];
+    for (const ms of marketplaceSkills) {
+      if (!merged.some((s) => s.id === ms.id)) {
+        merged.push(ms);
+      }
     }
-  }
+    return merged;
+  }, [marketplaceSkills]);
 
   const checkStatuses = useCallback(async () => {
     try {
@@ -38,8 +41,7 @@ export function useSkillStore() {
     } catch {
       // Silently fail — statuses will show as not installed
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mergedCatalog.length]);
+  }, [mergedCatalog]);
 
   useEffect(() => {
     checkStatuses();

--- a/src/hooks/useSkillStore.ts
+++ b/src/hooks/useSkillStore.ts
@@ -3,13 +3,32 @@ import { invoke } from "@tauri-apps/api/core";
 import { SKILL_CATALOG } from "../data/skill-catalog";
 import type { CatalogSkill, InstalledSkillStatus, InstallResult } from "../types/skill-catalog";
 
+interface MarketplaceSkill {
+  id: string;
+  name: string;
+  description: string;
+  sourceUrl: string;
+  repoUrl: string;
+}
+
 export function useSkillStore() {
   const [statuses, setStatuses] = useState<Map<string, boolean>>(new Map());
   const [installing, setInstalling] = useState<Set<string>>(new Set());
+  const [marketplaceSkills, setMarketplaceSkills] = useState<CatalogSkill[]>([]);
+  const [marketplaceLoading, setMarketplaceLoading] = useState(false);
+  const [marketplaceError, setMarketplaceError] = useState<string | null>(null);
+
+  // Merged catalog: hardcoded + any live marketplace entries not already in hardcoded
+  const mergedCatalog = [...SKILL_CATALOG];
+  for (const ms of marketplaceSkills) {
+    if (!mergedCatalog.some((s) => s.id === ms.id)) {
+      mergedCatalog.push(ms);
+    }
+  }
 
   const checkStatuses = useCallback(async () => {
     try {
-      const skillIds: [string, string][] = SKILL_CATALOG.map((s) => [s.id, s.format]);
+      const skillIds: [string, string][] = mergedCatalog.map((s) => [s.id, s.format]);
       const results = await invoke<InstalledSkillStatus[]>("check_skills_installed", { skillIds });
       const map = new Map<string, boolean>();
       for (const r of results) {
@@ -19,11 +38,48 @@ export function useSkillStore() {
     } catch {
       // Silently fail — statuses will show as not installed
     }
-  }, []);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mergedCatalog.length]);
 
   useEffect(() => {
     checkStatuses();
   }, [checkStatuses]);
+
+  const fetchMarketplace = useCallback(async (repo?: string) => {
+    setMarketplaceLoading(true);
+    setMarketplaceError(null);
+    try {
+      const skills = await invoke<MarketplaceSkill[]>("fetch_marketplace_skills", {
+        repo: repo || null,
+      });
+      const asCatalog: CatalogSkill[] = skills.map((s) => ({
+        id: s.id,
+        name: s.name,
+        description: s.description,
+        category: "Development" as const, // Default category for live skills
+        author: repo ? repo.split("/")[0] : "Anthropic",
+        sourceUrl: s.sourceUrl,
+        repoUrl: s.repoUrl,
+        format: "skill" as const,
+        featured: false,
+      }));
+      setMarketplaceSkills(asCatalog);
+      // Re-check installed statuses with new catalog
+      const allIds: [string, string][] = [...SKILL_CATALOG, ...asCatalog]
+        .filter((s, i, arr) => arr.findIndex((x) => x.id === s.id) === i)
+        .map((s) => [s.id, s.format]);
+      const results = await invoke<InstalledSkillStatus[]>("check_skills_installed", { skillIds: allIds });
+      const map = new Map<string, boolean>();
+      for (const r of results) {
+        map.set(r.id, r.installed);
+      }
+      setStatuses(map);
+    } catch (e) {
+      setMarketplaceError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setMarketplaceLoading(false);
+    }
+  }, []);
 
   const install = useCallback(async (skill: CatalogSkill) => {
     setInstalling((prev) => new Set(prev).add(skill.id));
@@ -62,11 +118,14 @@ export function useSkillStore() {
   }, [checkStatuses]);
 
   return {
-    catalog: SKILL_CATALOG,
+    catalog: mergedCatalog,
     statuses,
     installing,
     install,
     uninstall,
     refresh: checkStatuses,
+    fetchMarketplace,
+    marketplaceLoading,
+    marketplaceError,
   };
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -944,6 +944,66 @@ html, body, #root {
   color: var(--text-primary);
 }
 
+.new-tab-group {
+  position: relative;
+  display: flex;
+  gap: 0;
+}
+
+.new-tab-btn.dropdown-toggle {
+  padding: 4px 4px;
+  font-size: 9px;
+  color: var(--text-muted);
+  margin-left: -4px;
+}
+
+.new-tab-btn.dropdown-toggle:hover {
+  color: var(--accent-orange);
+}
+
+.quick-actions-dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 4px;
+  z-index: 100;
+  min-width: 160px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.quick-action-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  cursor: pointer;
+  border-radius: 4px;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.quick-action-item:hover {
+  background: var(--bg-hover);
+  color: var(--accent-orange);
+}
+
+.quick-action-icon {
+  color: var(--text-muted);
+  font-size: 10px;
+  width: 12px;
+  text-align: center;
+}
+
 .split-view-btn {
   background: none;
   border: 1px solid var(--border-color);
@@ -1410,6 +1470,47 @@ html, body, #root {
 
 .skills-search::placeholder {
   color: var(--text-muted);
+}
+
+.skills-repo-search {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.skills-repo-search .skills-search {
+  flex: 1;
+  margin-bottom: 0;
+}
+
+.skills-fetch-btn {
+  background: var(--bg-hover);
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.skills-fetch-btn:hover {
+  background: var(--accent-orange-glow);
+  color: var(--accent-orange);
+  border-color: var(--accent-orange);
+}
+
+.skills-fetch-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.skills-error {
+  color: var(--danger);
+  font-size: 11px;
+  padding: 4px 8px;
+  margin-bottom: 8px;
 }
 
 .skills-group {


### PR DESCRIPTION
## Summary

Three improvements to how skills work in Canopy:

### 1. Fix: Complete skill directory installation
Previously `install_skill` only downloaded `SKILL.md`, breaking skills that depend on `scripts/`, `references/`, or `assets/` subdirectories (like PDF, XLSX, frontend-design, etc.). Now uses the GitHub Contents API to recursively download the entire skill directory.

### 2. Quick workflow actions in tab bar
The "+ Claude" button now has a dropdown with common developer workflows:
- **Review PR** — Review current branch against main
- **Fix Tests** — Find and fix failing tests
- **Commit** — Smart commit with doc sync
- **Plan Feature** — Architecture planning before coding
- **Audit Code** — Code quality review
- **Simplify** — Clean up recent changes

These open Claude sessions with pre-loaded prompts — no installation needed. They feel like natural actions, not "skills."

### 3. Live marketplace search
The Browse Store tab can now search any GitHub repo that follows the skills directory convention. Type a repo like `anthropics/skills` or any community repo and hit Search to discover available skills dynamically. Results merge with the built-in catalog.

## Test plan
- [x] All 153 TypeScript tests pass (including updated contract test)
- [x] All Rust tests pass
- [x] `tsc --noEmit` clean
- [x] `cargo check` clean
- [ ] Manual: Install a skill (e.g. PDF) — verify scripts/ directory downloads
- [ ] Manual: Click dropdown arrow next to "+ Claude" — verify quick actions menu
- [ ] Manual: In Browse Store, search `anthropics/skills` — verify live results
- [ ] Manual: Search a community repo — verify results appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)