### PR TITLE
Fix console window flashing on Windows

### DIFF
--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -1,4 +1,5 @@
 use super::terminal::ensure_full_path;
+use super::CommandNoWindow;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fs;
@@ -114,7 +115,7 @@ fn find_github_repo(project_path: &str) -> Option<String> {
 pub async fn get_github_items(project_paths: Vec<String>) -> GitHubData {
     // Check if gh CLI is available
     let full_path = ensure_full_path();
-    let gh_check = Command::new("gh").arg("--version").env("PATH", &full_path).output();
+    let gh_check = Command::new("gh").no_window().arg("--version").env("PATH", &full_path).output();
     if !matches!(gh_check, Ok(ref o) if o.status.success()) {
         return GitHubData {
             prs: vec![],
@@ -149,6 +150,7 @@ pub async fn get_github_items(project_paths: Vec<String>) -> GitHubData {
 
             // Fetch PRs authored by the current user
             if let Ok(output) = Command::new("gh")
+                .no_window()
                 .args([
                     "pr", "list",
                     "--author", "@me",
@@ -181,6 +183,7 @@ pub async fn get_github_items(project_paths: Vec<String>) -> GitHubData {
 
             // Also fetch PRs where I'm requested as reviewer
             if let Ok(output) = Command::new("gh")
+                .no_window()
                 .args([
                     "search", "prs",
                     "--review-requested", "@me",
@@ -217,6 +220,7 @@ pub async fn get_github_items(project_paths: Vec<String>) -> GitHubData {
 
             // Fetch PRs assigned to the current user
             if let Ok(output) = Command::new("gh")
+                .no_window()
                 .args([
                     "pr", "list",
                     "--assignee", "@me",
@@ -252,6 +256,7 @@ pub async fn get_github_items(project_paths: Vec<String>) -> GitHubData {
 
             // Fetch assigned issues
             if let Ok(output) = Command::new("gh")
+                .no_window()
                 .args([
                     "issue", "list",
                     "--assignee", "@me",

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,3 +4,23 @@ pub mod projects;
 pub mod skills;
 pub mod github;
 pub mod settings;
+
+/// Extension trait to suppress console windows on Windows GUI apps.
+/// On non-Windows platforms this is a no-op.
+pub trait CommandNoWindow {
+    fn no_window(&mut self) -> &mut Self;
+}
+
+impl CommandNoWindow for std::process::Command {
+    #[cfg(windows)]
+    fn no_window(&mut self) -> &mut Self {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        self.creation_flags(CREATE_NO_WINDOW)
+    }
+
+    #[cfg(not(windows))]
+    fn no_window(&mut self) -> &mut Self {
+        self
+    }
+}

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -1,3 +1,4 @@
+use super::CommandNoWindow;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -153,6 +154,7 @@ struct GitHubContentEntry {
 /// Download a single file from a URL to a local path
 fn download_file(url: &str, dest: &Path) -> Result<(), String> {
     let output = Command::new("curl")
+        .no_window()
         .args(["-s", "--fail", "--connect-timeout", "10", "--max-time", "30", url])
         .output()
         .map_err(|e| format!("Failed to run curl: {}", e))?;
@@ -182,6 +184,7 @@ fn download_github_directory_inner(api_url: &str, target_dir: &Path, depth: u32)
 
     // Fetch directory listing from GitHub Contents API
     let output = Command::new("curl")
+        .no_window()
         .args([
             "-s", "--fail",
             "--connect-timeout", "10",
@@ -508,6 +511,7 @@ pub fn fetch_marketplace_skills(repo: Option<String>) -> Result<Vec<MarketplaceS
     );
 
     let output = Command::new("curl")
+        .no_window()
         .args([
             "-s", "--fail",
             "--connect-timeout", "10",
@@ -542,6 +546,7 @@ pub fn fetch_marketplace_skills(repo: Option<String>) -> Result<Vec<MarketplaceS
         );
 
         let md_output = Command::new("curl")
+            .no_window()
             .args(["-s", "--fail", &skill_url])
             .output();
 

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -1,3 +1,4 @@
+use super::CommandNoWindow;
 use crate::state::AppState;
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use serde::Serialize;
@@ -66,6 +67,7 @@ pub fn check_claude_cli() -> ClaudeCliStatus {
         ("which", "claude")
     };
     match std::process::Command::new(cmd)
+        .no_window()
         .arg(arg)
         .env("PATH", &full_path)
         .output()


### PR DESCRIPTION
## Summary

- Add `CommandNoWindow` extension trait that sets `CREATE_NO_WINDOW` (0x08000000) creation flag on Windows (no-op on other platforms)
- Apply `.no_window()` to all 10 `Command::new()` call sites across `github.rs`, `skills.rs`, and `terminal.rs`

Closes #66

## Test plan

- [x] `cargo check` passes
- [x] All 52 existing tests pass (`cargo test`)
- [x] Build release on Windows and verify no console windows flash on startup