### PR TITLE
Fix IME candidate window drifting during CJK composition

### DIFF
--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -153,13 +153,17 @@ export function TerminalView({
     xtermRef.current = xterm;
     fitAddonRef.current = fitAddon;
 
-    // IME: set CSS custom property for cell height (used by padding-top)
+    // IME: set CSS custom property for cell height (used by padding-top).
+    // onRender fires every frame during output, so skip when value is unchanged
+    // to avoid unnecessary DOM writes.
+    let lastCellHeight = 0;
     const syncCellHeight = () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const dims = (xterm as any)._core?._renderService?.dimensions;
-      if (dims?.css?.cell?.height) {
-        container.style.setProperty("--xterm-cell-height", dims.css.cell.height + "px");
-      }
+      const h = dims?.css?.cell?.height;
+      if (!h || h === lastCellHeight) return;
+      lastCellHeight = h;
+      container.style.setProperty("--xterm-cell-height", h + "px");
     };
     xterm.onRender(syncCellHeight);
 

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -153,8 +153,35 @@ export function TerminalView({
     xtermRef.current = xterm;
     fitAddonRef.current = fitAddon;
 
+    // IME: set CSS custom property for cell height (used by padding-top)
+    const syncCellHeight = () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const dims = (xterm as any)._core?._renderService?.dimensions;
+      if (dims?.css?.cell?.height) {
+        container.style.setProperty("--xterm-cell-height", dims.css.cell.height + "px");
+      }
+    };
+    xterm.onRender(syncCellHeight);
+
+    // IME: lock textarea top position during composition so status bar
+    // updates don't cause the IME candidate window to jump vertically
+    const imeTextarea = container.querySelector(".xterm-helper-textarea") as HTMLTextAreaElement | null;
+    if (imeTextarea) {
+      imeTextarea.addEventListener("compositionstart", () => {
+        const currentTop = imeTextarea.style.top;
+        imeTextarea.style.setProperty("--ime-locked-top", currentTop);
+        imeTextarea.classList.add("ime-locked");
+      });
+      imeTextarea.addEventListener("compositionend", () => {
+        imeTextarea.classList.remove("ime-locked");
+      });
+    }
+
     // Fit after a frame so container has real dimensions
-    requestAnimationFrame(() => fitAddon.fit());
+    requestAnimationFrame(() => {
+      fitAddon.fit();
+      syncCellHeight();
+    });
 
     // Guard: if Claude CLI is not available, show help instead of spawning
     if (tab.isClaudeSession && claudeCliAvailable === false) {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1067,6 +1067,34 @@ html, body, #root {
   overflow-y: auto !important;
 }
 
+/* IME fix: prevent candidate window drift during composition.
+   Chromium positions IME window based on internal caret bounds.
+   letter-spacing collapses all characters to zero width so the
+   caret never advances, keeping the IME window anchored.
+   padding-top pushes the caret down so the IME window appears
+   below the terminal text instead of overlapping it. */
+.terminal-container .xterm-helper-textarea {
+  left: 0px !important;
+  width: 1px !important;
+  font-size: 1px !important;
+  letter-spacing: -1em !important;
+  padding-top: var(--xterm-cell-height, 18px) !important;
+  overflow: hidden !important;
+}
+/* During composition, lock top position via CSS variable set by JS */
+.terminal-container .xterm-helper-textarea.ime-locked {
+  top: var(--ime-locked-top) !important;
+}
+
+/* Hide the composition preview text visually but keep element in DOM
+   so xterm.js IME processing pipeline continues to work */
+.terminal-container .composition-view {
+  opacity: 0 !important;
+  width: 1px !important;
+  height: 1px !important;
+  overflow: hidden !important;
+}
+
 /* ── Terminal Search Bar ── */
 .terminal-search-bar {
   position: absolute;


### PR DESCRIPTION
## Summary

- Stabilize IME candidate window position during CJK composition via CSS overrides on `.xterm-helper-textarea` (`letter-spacing: -1em`, `left: 0`, `width: 1px`)
- Hide `composition-view` overlay that rendered ghost pre-edit text at wrong position
- Lock `top` position during composition to prevent vertical jumps from status bar updates
- Sync `--xterm-cell-height` CSS variable on render for dynamic `padding-top`

Closes #68

## Test plan

- [x] TypeScript type check passes
- [x] All 155 frontend tests pass (`npm test`)
- [x] On Windows, open a terminal session and type CJK text via IME
- [x] Verify IME candidate window stays anchored at terminal left edge
- [x] Verify no ghost pre-edit text at top-left of terminal
- [x] Verify candidate window does not jump when status bar updates
- [x] Verify English input still works normally