### PR TITLE
Add Ctrl+Shift+C/V for terminal copy-paste

### DIFF
--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -153,6 +153,31 @@ export function TerminalView({
     xtermRef.current = xterm;
     fitAddonRef.current = fitAddon;
 
+    // Copy/paste keyboard shortcuts (Ctrl+Shift+C / Ctrl+Shift+V)
+    // These don't conflict with SIGINT (Ctrl+C) and match xterm convention.
+    xterm.attachCustomKeyEventHandler((e) => {
+      if (e.type !== "keydown") return true;
+      const mod = e.ctrlKey || e.metaKey;
+      if (mod && e.shiftKey && (e.key === "C" || e.key === "c")) {
+        const selection = xterm.getSelection();
+        if (selection) {
+          navigator.clipboard.writeText(selection).catch(console.error);
+        }
+        e.preventDefault();
+        return false;
+      }
+      if (mod && e.shiftKey && (e.key === "V" || e.key === "v")) {
+        navigator.clipboard.readText().then((text) => {
+          if (terminalIdRef.current && text) {
+            writeToTerminal(terminalIdRef.current, text).catch(console.error);
+          }
+        }).catch(console.error);
+        e.preventDefault();
+        return false;
+      }
+      return true;
+    });
+
     // Fit after a frame so container has real dimensions
     requestAnimationFrame(() => fitAddon.fit());
 


### PR DESCRIPTION
## Summary

- \`Ctrl+Shift+C\` / \`Cmd+Shift+C\`: copy terminal selection to clipboard
- \`Ctrl+Shift+V\` / \`Cmd+Shift+V\`: paste clipboard content into PTY
- \`preventDefault()\` blocks the Chromium DevTools shortcut from overriding Ctrl+Shift+C

Uses xterm.js \`attachCustomKeyEventHandler\` to avoid conflicts with SIGINT (Ctrl+C). Matches standard xterm terminal conventions.

Closes #81

## Test plan

- [x] TypeScript type check passes
- [x] All 155 frontend tests pass
- [x] Select text in terminal and press Ctrl+Shift+C → text is copied
- [x] Press Ctrl+Shift+V → clipboard content is pasted into terminal
- [x] Ctrl+C still sends SIGINT to running processes