### PR TITLE
Reduce per-output allocations and cascade re-renders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,10 @@ function App() {
   // Registry of terminal container DOM elements for hit-testing during OS drag
   const terminalElementsRef = useRef<Map<string, HTMLElement>>(new Map());
 
+  // Read-only tabs ref for event handlers that shouldn't re-create on every tab change
+  const tabsRef = useRef(tabs);
+  tabsRef.current = tabs;
+
   useEffect(() => {
     const activeTab = tabs.find((t) => t.id === activeTabId);
     activeTerminalIdRef.current = activeTab?.terminalId ?? null;
@@ -163,7 +167,7 @@ function App() {
         getCurrentWindow().requestUserAttention(UserAttentionType.Informational).catch(console.error);
 
         // Update dock badge with count of tabs needing attention
-        const attentionCount = tabs.filter((t) => t.status === "waiting").length + 1;
+        const attentionCount = tabsRef.current.filter((t) => t.status === "waiting").length + 1;
         getCurrentWindow().setBadgeCount(attentionCount).catch(console.error);
 
         if (notifSettingsRef.current.toastNotifications) {
@@ -179,7 +183,7 @@ function App() {
         }
       }
     },
-    [setTabStatus, addToast, tabs]
+    [setTabStatus, addToast]
   );
 
   const selectTab = useCallback(

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { ask } from "@tauri-apps/plugin-dialog";
 import type { Project } from "../../types/project";
 import type { Workspace } from "../../services/database-service";
@@ -26,27 +27,31 @@ export function Sidebar({
   onRemoveWorkspace,
   onGoHome,
 }: SidebarProps) {
-  // Group projects by workspace
-  const workspaceProjects = new Map<string, Project[]>();
-  const standaloneProjects: Project[] = [];
+  // Group projects by workspace, memoized by projects reference
+  const { workspaceProjects, standaloneProjects } = useMemo(() => {
+    const wp = new Map<string, Project[]>();
+    const sa: Project[] = [];
 
-  for (const p of projects) {
-    if (p.workspace_path) {
-      const existing = workspaceProjects.get(p.workspace_path) || [];
-      existing.push(p);
-      workspaceProjects.set(p.workspace_path, existing);
-    } else {
-      standaloneProjects.push(p);
+    for (const p of projects) {
+      if (p.workspace_path) {
+        const existing = wp.get(p.workspace_path) || [];
+        existing.push(p);
+        wp.set(p.workspace_path, existing);
+      } else {
+        sa.push(p);
+      }
     }
-  }
 
-  // Sort workspace projects alphabetically
-  for (const [key, val] of workspaceProjects) {
-    workspaceProjects.set(
-      key,
-      val.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }))
-    );
-  }
+    // Sort workspace projects alphabetically
+    for (const [key, val] of wp) {
+      wp.set(
+        key,
+        val.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }))
+      );
+    }
+
+    return { workspaceProjects: wp, standaloneProjects: sa };
+  }, [projects]);
 
   return (
     <div className="sidebar">

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -14,6 +14,10 @@ import {
   resizeTerminal,
 } from "../../services/terminal-service";
 
+// Shared decoder/regex — reused across output events to reduce GC pressure
+const TEXT_DECODER = new TextDecoder();
+const ANSI_ESCAPE_RE = /\x1b\[[0-9;]*[a-zA-Z]/g;
+
 const XTERM_THEME = {
   background: "#0D0D0D",
   foreground: "#E0E0E0",
@@ -239,8 +243,11 @@ export function TerminalView({
             }, IDLE_THRESHOLD_MS);
 
             // Strip ANSI escape sequences and check for attention patterns
-            const text = new TextDecoder().decode(bytes).replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
-            checkForAttentionNeeded(text);
+            // Guard with isClaudeSession — shell tabs don't need this work
+            if (tab.isClaudeSession) {
+              const text = TEXT_DECODER.decode(bytes).replace(ANSI_ESCAPE_RE, "");
+              checkForAttentionNeeded(text);
+            }
           } else if (event.type === "exit") {
             // Clear idle timer
             if (idleTimerRef.current) clearTimeout(idleTimerRef.current);


### PR DESCRIPTION
## Summary

- Hoist \`TextDecoder\` and ANSI escape regex to module scope; skip for non-Claude tabs where the stripped text isn't consumed
- Memoize Sidebar workspace grouping/sorting by \`projects\` reference
- Move \`tabs\` read in \`handleStatusChange\` to a ref so the callback isn't recreated on every tab state change

Closes #83

## Test plan

- [x] TypeScript type check passes
- [x] All 155 frontend tests pass
- [ ] Run a high-output command (e.g. \`ls -R /\`) in a shell tab and verify no regression in rendering
- [ ] Verify waiting badge count still updates correctly on \`handleStatusChange\`